### PR TITLE
LWA power beam for CHIME alerts

### DIFF
--- a/ovro_alert/lwa_alert_client.py
+++ b/ovro_alert/lwa_alert_client.py
@@ -2,11 +2,14 @@ from time import sleep
 from astropy.time import Time
 from ovro_alert.alert_client import AlertClient
 from mnc import control
+import threading
+
 
 class LWAAlertClient(AlertClient):
-    def __init__(self, pipelines):
+    def __init__(self, con):
 	super().__init__('lwa')
-        self.pipelines = [p for p in pipelines if p.pipeline_id in [2, 3]]
+	self.con = con
+        self.pipelines = [p for p in con.pipelines if p.pipeline_id in [2, 3]]
         self.ntime_per_file = 1024
         self.nfile = 1
 
@@ -21,6 +24,8 @@ class LWAAlertClient(AlertClient):
                 dd = dd2.copy()
                 if dd2["command"] == "trigger":
                     self.trigger()
+		elif dd2["command"] == "CHIME FRB" and all(key in dd2 for key in ["dm", "toa", "position"]):
+                    self.powerbeam(dd2)
             else:
                 sleep(loop)
                 continue
@@ -35,16 +40,37 @@ class LWAAlertClient(AlertClient):
             		pipeline.triggered_dump.trigger(ntime_per_file=self.ntime_per_file, nfile=self.nfile, dump_path=path)
 
 
-    def powerbeam(self):
+    def powerbeam(self, dd2):
         """ Observe with power beam
         """
-        pass
+	args = dd2  # Use dd2 directly
+    	position = args["position"].split(",")  # Parse the position to get ra and dec
 
+    	RA = float(position[0])  
+    	Dec = float(position[1]) 
+
+	dm = dd2["dm"]
+	toa = dd2["toa"]
+
+	max_delay = 4.149*1e3 * dm * 12**(-2) # maximum delay for a specific value of DM at the lowest LWA frequency (12 MHz) in seconds
+
+
+        self.con.configure_xengine(recorders=['dr1'], calibratebeams=True)
+    	thread = threading.Thread(target=self.con.control_bf, kwargs={'num': 1, 'targetname': (RA, Dec), 'track': True})
+    	thread.start()
+	
+
+	#Observe for the duration equal to maximum delay (duration is in ms)	
+    	self.con.start_dr(recorders=['dr1'], duration=max_delay*1e3, time_avg=128)
+
+	# Sleep for the duration + 10 sec, then stop the recording and the xengine
+    	time.sleep(max_delay + 10)  
+    	self.con.stop_dr(recorders=['dr1'])
+    	self.con.stop_xengine()
 
 if __name__ == '__main__':
     con = control.Controller()
-    pipelines = con.pipelines
-    client = LWAAlertClient(pipelines)
+    client = LWAAlertClient(con)
     client.ntime_per_file = 24000
     client.nfile = 1
     client.poll(loop=5)

--- a/ovro_alert/lwa_alert_client.py
+++ b/ovro_alert/lwa_alert_client.py
@@ -24,7 +24,7 @@ class LWAAlertClient(AlertClient):
                 dd = dd2.copy()
                 if dd2["command"] == "trigger":
                     self.trigger()
-		elif dd2["command"] == "CHIME FRB" and all(key in dd2 for key in ["dm", "toa", "position"]):
+		elif dd2["command"] == "powerbeam" and all(key in dd2 for key in ["dm", "toa", "position"]):
                     self.powerbeam(dd2)
             else:
                 sleep(loop)
@@ -55,7 +55,6 @@ class LWAAlertClient(AlertClient):
 	max_delay = 4.149*1e3 * dm * 12**(-2) # maximum delay for a specific value of DM at the lowest LWA frequency (12 MHz) in seconds
 
 
-        self.con.configure_xengine(recorders=['dr1'], calibratebeams=True)
     	thread = threading.Thread(target=self.con.control_bf, kwargs={'num': 1, 'targetname': (RA, Dec), 'track': True})
     	thread.start()
 	


### PR DESCRIPTION
@caseyjlaw, I've been working on adding a feature that will allow to do beamformed observations in case of a CHIME alert. I believe this script https://github.com/ovrocaltech/Comet/blob/b9665d520d027a0c6b95772debd47d7bf472e192/comet/plugins/eventwriter.py can be easily modified to send these alerts to LWA. 
Can you check my implementation? 
One thing I'm really not sure of -- when beam starts tracking one needs to open a new terminal to start data recording. I've used threading to do this: 
https://github.com/ovrocaltech/ovro-alert/blob/9eda31d14a33fe3dd5cdc1623b2b79296c448ab8/ovro_alert/lwa_alert_client.py#L59-L64
Is there a better way to do it?