### PR TITLE
Ligo alert script modifications

### DIFF
--- a/ligo-alert/gcn-buffer_trigger.py
+++ b/ligo-alert/gcn-buffer_trigger.py
@@ -75,34 +75,18 @@ def process_gcn(payload, root, write=True):
 
         # Send to relay
         # for EarlyWarning type of Alerts
-        if condition1:
-            print(f'sending EarlyWarning type of alert to ligo relay server with role observation')
+        role = "observation" if condition1 else root.attrib["role"]
+        msg_start = "sending EarlyWarning type of alert" if condition1 else "sending alert"
 
-            ligoc.set("observation", args={'FAR': params['FAR'], 'BNS': params['BNS'],
-                                                 'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
-            # Send to slack if necessary
-            if send_to_slack:
-                # Prepare the message to be sent to Slack
-                slack_message = f"GraceID: {params['GraceID']}, AlertType: {params['AlertType']}" \
-                                f", Parameters: FAR {params['FAR']}, BNS {params['BNS']}, HasNS {params['HasNS']}" \
-                                f", Terrestrial {params['Terrestrial']}. Message sent at (UTC): {now.strftime('%Y-%m-%d %H:%M:%S')}."
-                post_to_slack(slack_channel, slack_message)
+        print(f'{msg_start} to ligo relay server with role {role}')
+        ligoc.set(role, args={'FAR': params['FAR'], 'BNS': params['BNS'],
+                              'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
 
-
-        # in case of real observation
-        elif condition2:
-
-            print(f'sending to ligo relay server with role {root.attrib["role"]}')
-
-            ligoc.set(root.attrib['role'], args={'FAR': params['FAR'], 'BNS': params['BNS'],
-                                                     'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
-            # Send to slack if necessary
-            if send_to_slack:
-                # Prepare the message to be sent to Slack
-                slack_message = f"GraceID: {params['GraceID']}, AlertType: {params['AlertType']}" \
-                                f", Parameters: FAR {params['FAR']}, BNS {params['BNS']}, HasNS {params['HasNS']}" \
-                                f", Terrestrial {params['Terrestrial']}. Message sent at (UTC): {now.strftime('%Y-%m-%d %H:%M:%S')}."
-                post_to_slack(slack_channel, slack_message)
+        if send_to_slack:
+            slack_message = f"GraceID: {params['GraceID']}, AlertType: {params['AlertType']}" \
+                            f", Parameters: FAR {params['FAR']}, BNS {params['BNS']}, HasNS {params['HasNS']}" \
+                            f", Terrestrial {params['Terrestrial']}. Message sent at (UTC): {now.strftime('%Y-%m-%d %H:%M:%S')}."
+            post_to_slack(slack_channel, slack_message)
 
 
         # Save bayestar map

--- a/ligo-alert/gcn-buffer_trigger.py
+++ b/ligo-alert/gcn-buffer_trigger.py
@@ -33,8 +33,9 @@ def process_gcn(payload, root, write=True):
     
     # Respond to both 'test' in case of EarlyWarning alert or 'observation' 
     condition1 = root.attrib['role'] == 'test' and params['AlertType'] == 'EarlyWarning'
-    condition2 = root.attrib['role'] == 'observation' # IMPORTANT! for real observations set to 'observation' 
-    if not (condition1 or condition2):
+    condition2 = root.attrib['role'] == 'observation' # IMPORTANT! for real observations set to 'observation'
+    condition3 = root.attrib['role'] == 'test' # For testing purposes
+    if not (condition1 or condition2 or condition3):
         return
 
     # If event is retracted, print it.
@@ -70,12 +71,41 @@ def process_gcn(payload, root, write=True):
                 f.write("Created at (UTC): " + now.strftime("%Y-%m-%d %H:%M:%S"))
 
         # Send to relay
-        print(f'sending to ligo relay server with role {root.attrib["role"]}')
-        # TODO: logic to catch "test" role for advanced warning
-        # TODO: do we need to select on whether target is up?
-        # TODO: save bayestar region
-        ligoc.set(root.attrib['role'], args={'FAR': params['FAR'], 'BNS': params['BNS'],
-                                             'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
+        # for EarlyWarning type of Alerts
+        if condition1:
+            print(f'sending EarlyWarning type of alert to ligo relay server with role observation')
+
+            ligoc.set("observation", args={'FAR': params['FAR'], 'BNS': params['BNS'],
+                                                 'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
+        # in case of real observation
+        elif condition2:
+
+            print(f'sending to ligo relay server with role {root.attrib["role"]}')
+
+            ligoc.set(root.attrib['role'], args={'FAR': params['FAR'], 'BNS': params['BNS'],
+                                                     'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
+        # for testing, send with nsamp parameter
+        elif condition3:
+
+            print(f'sending to ligo relay server with role {root.attrib["role"]}')
+
+            ligoc.set(root.attrib['role'], args={'FAR': params['FAR'], 'BNS': params['BNS'],
+                                                 'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial'],
+                                                 'nsamp': 24000})
+
+
+        # Save bayestar map
+        if 'skymap_fits' in params:
+            # Read the HEALPix sky map and the FITS header.
+            skymap, _ = ligo.skymap.io.read_sky_map(params['skymap_fits'])
+
+            # Write the skymap to a file
+            skymap_file_name = params['GraceID'] + '_skymap.fits'
+            ligo.skymap.io.write_sky_map(skymap_file_name, skymap, overwrite=True)
+
+            # TODO: logic to catch "test" role for advanced warning
+            # TODO: do we need to select on whether target is up?
+
     else:
         print(f'Event did not pass selection: FAR {params["FAR"]}, BNS {params["BNS"]}, Terrestrial {params["Terrestrial"]}.')
             

--- a/ligo-alert/gcn-buffer_trigger.py
+++ b/ligo-alert/gcn-buffer_trigger.py
@@ -4,7 +4,14 @@ from ovro_alert import alert_client
 import ligo.skymap.io
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
+from os import environ
 
+
+if "SLACK_TOKEN_CR" in environ:
+    slack_token = environ["SLACK_TOKEN_CR"]
+    slack_channel = "#alert-driven-astro"  # use your actual Slack channel (TBD)
+    client = WebClient(token=slack_token)
+send_to_slack = False  # global variable to control whether to send to Slack
 
 ligoc = alert_client.AlertClient('ligo')
 
@@ -14,10 +21,7 @@ ASTRO_PROB_THRESH = 0.9 # not Terrestrial
 HAS_NS_THRESH = 0.9 # HasNS probability
 BNS_NSBH_THRESH = 0 # Either BNS or NSBH probability
 
-slack_token = "your-slack-token"  # use your actual Slack token (TBD)
-slack_channel = "#your-channel"  # use your actual Slack channel (TBD)
-client = WebClient(token=slack_token)
-send_to_slack = False  # global variable to control whether to send to Slack
+
 
 def post_to_slack(channel, message):
     """Post a message to a Slack channel."""

--- a/ligo-alert/gcn-buffer_trigger.py
+++ b/ligo-alert/gcn-buffer_trigger.py
@@ -14,8 +14,8 @@ ASTRO_PROB_THRESH = 0.9 # not Terrestrial
 HAS_NS_THRESH = 0.9 # HasNS probability
 BNS_NSBH_THRESH = 0 # Either BNS or NSBH probability
 
-slack_token = "your-slack-token"  # use your actual Slack token
-slack_channel = "#your-channel"  # use your actual Slack channel
+slack_token = "your-slack-token"  # use your actual Slack token (TBD)
+slack_channel = "#your-channel"  # use your actual Slack channel (TBD)
 client = WebClient(token=slack_token)
 send_to_slack = False  # global variable to control whether to send to Slack
 
@@ -48,8 +48,7 @@ def process_gcn(payload, root, write=True):
     # Respond to both 'test' in case of EarlyWarning alert or 'observation' 
     condition1 = root.attrib['role'] == 'test' and params['AlertType'] == 'EarlyWarning'
     condition2 = root.attrib['role'] == 'observation' # IMPORTANT! for real observations set to 'observation'
-    condition3 = root.attrib['role'] == 'test' # For testing purposes
-    if not (condition1 or condition2 or condition3):
+    if not (condition1 or condition2):
         return
 
     # If event is retracted, print it.
@@ -104,16 +103,6 @@ def process_gcn(payload, root, write=True):
                                 f", Parameters: FAR {params['FAR']}, BNS {params['BNS']}, HasNS {params['HasNS']}" \
                                 f", Terrestrial {params['Terrestrial']}. Message sent at (UTC): {now.strftime('%Y-%m-%d %H:%M:%S')}."
                 post_to_slack(slack_channel, slack_message)
-
-
-        # for testing, send with nsamp parameter
-        elif condition3:
-
-            print(f'sending to ligo relay server with role {root.attrib["role"]}')
-
-            ligoc.set(root.attrib['role'], args={'FAR': params['FAR'], 'BNS': params['BNS'],
-                                                 'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial'],
-                                                 'nsamp': 24000})
 
 
         # Save bayestar map

--- a/ligo-alert/gcn-buffer_trigger.py
+++ b/ligo-alert/gcn-buffer_trigger.py
@@ -1,7 +1,7 @@
 import gcn
 import datetime
 from ovro_alert import alert_client
-
+import ligo.skymap.io
 
 ligoc = alert_client.AlertClient('ligo')
 

--- a/ligo-alert/gcn-buffer_trigger.py
+++ b/ligo-alert/gcn-buffer_trigger.py
@@ -2,6 +2,9 @@ import gcn
 import datetime
 from ovro_alert import alert_client
 import ligo.skymap.io
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
 
 ligoc = alert_client.AlertClient('ligo')
 
@@ -11,6 +14,17 @@ ASTRO_PROB_THRESH = 0.9 # not Terrestrial
 HAS_NS_THRESH = 0.9 # HasNS probability
 BNS_NSBH_THRESH = 0 # Either BNS or NSBH probability
 
+slack_token = "your-slack-token"  # use your actual Slack token
+slack_channel = "#your-channel"  # use your actual Slack channel
+client = WebClient(token=slack_token)
+send_to_slack = False  # global variable to control whether to send to Slack
+
+def post_to_slack(channel, message):
+    """Post a message to a Slack channel."""
+    try:
+        response = client.chat_postMessage(channel=channel, text=message)
+    except SlackApiError as e:
+        print(f"Error sending to Slack: {e.response['error']}")
 
 # Function to call every time a GCN is received.
 # Run only for notices of type
@@ -60,16 +74,6 @@ def process_gcn(payload, root, write=True):
         # Create a datetime object with the current time in UTC
         now = datetime.datetime.utcnow()
 
-        # Open a new file in write mode
-        if write and root.attrib['role'] != 'test':
-            file_name = params['GraceID']+'_ligo.txt'
-            with open(file_name, "w") as f:
-                # Write the text "Trigger the buffer,"
-                f.write("Trigger the buffer,\n")
-
-                # Write the current time in UTC in a human-readable format
-                f.write("Created at (UTC): " + now.strftime("%Y-%m-%d %H:%M:%S"))
-
         # Send to relay
         # for EarlyWarning type of Alerts
         if condition1:
@@ -77,6 +81,15 @@ def process_gcn(payload, root, write=True):
 
             ligoc.set("observation", args={'FAR': params['FAR'], 'BNS': params['BNS'],
                                                  'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
+            # Send to slack if necessary
+            if send_to_slack:
+                # Prepare the message to be sent to Slack
+                slack_message = f"GraceID: {params['GraceID']}, AlertType: {params['AlertType']}" \
+                                f", Parameters: FAR {params['FAR']}, BNS {params['BNS']}, HasNS {params['HasNS']}" \
+                                f", Terrestrial {params['Terrestrial']}. Message sent at (UTC): {now.strftime('%Y-%m-%d %H:%M:%S')}."
+                post_to_slack(slack_channel, slack_message)
+
+
         # in case of real observation
         elif condition2:
 
@@ -84,6 +97,15 @@ def process_gcn(payload, root, write=True):
 
             ligoc.set(root.attrib['role'], args={'FAR': params['FAR'], 'BNS': params['BNS'],
                                                      'HasNS': params['HasNS'], 'Terrestrial': params['Terrestrial']})
+            # Send to slack if necessary
+            if send_to_slack:
+                # Prepare the message to be sent to Slack
+                slack_message = f"GraceID: {params['GraceID']}, AlertType: {params['AlertType']}" \
+                                f", Parameters: FAR {params['FAR']}, BNS {params['BNS']}, HasNS {params['HasNS']}" \
+                                f", Terrestrial {params['Terrestrial']}. Message sent at (UTC): {now.strftime('%Y-%m-%d %H:%M:%S')}."
+                post_to_slack(slack_channel, slack_message)
+
+
         # for testing, send with nsamp parameter
         elif condition3:
 
@@ -103,7 +125,6 @@ def process_gcn(payload, root, write=True):
             skymap_file_name = params['GraceID'] + '_skymap.fits'
             ligo.skymap.io.write_sky_map(skymap_file_name, skymap, overwrite=True)
 
-            # TODO: logic to catch "test" role for advanced warning
             # TODO: do we need to select on whether target is up?
 
     else:


### PR DESCRIPTION
@caseyjlaw I've made some changes to the ligo receiving script. Can you please review them?
To post to slack, token and channel should be specified: https://github.com/ovrocaltech/ovro-alert/blob/a97d490a4b0b64d5725fadf7983b36be6daafea3/ligo-alert/gcn-buffer_trigger.py#L17-L18
Now the special case when the role of an alert is "test" and its type is "EarlyWarning" is treated as it was observation:
https://github.com/ovrocaltech/ovro-alert/blob/a97d490a4b0b64d5725fadf7983b36be6daafea3/ligo-alert/gcn-buffer_trigger.py#L78-L83
It is also possible to save the map for the corresponding alert in case it's provided:
https://github.com/ovrocaltech/ovro-alert/blob/a97d490a4b0b64d5725fadf7983b36be6daafea3/ligo-alert/gcn-buffer_trigger.py#LL99C6-L99C6 
