### PR TITLE
GCN Classic over Kafka consumer for Swift alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Code and services for sending, receiving, and using astronomical alerts at OVRO.
 - slack_sdk
 - astropy
 - pygcn
+- gcn-kafka
 
 ## Design and Assumptions
 

--- a/gcn-alert/gcn_kafka_receiver.py
+++ b/gcn-alert/gcn_kafka_receiver.py
@@ -26,7 +26,7 @@ if not client_id or not client_secret:
     sys.exit(1)
 
 slack_token = environ.get("SLACK_TOKEN_CR")
-slack_channel = "#alert-driven-astro"  # use your actual Slack channel
+slack_channel = "#alert-driven-astro"  
 send_to_slack = bool(slack_token)
 
 if slack_token:
@@ -35,7 +35,10 @@ if slack_token:
 
 consumer = Consumer(client_id=client_id, client_secret=client_secret)
 
-consumer.subscribe(['gcn.notices.swift.bat.guano'])  # Add 'gcn.notices.einstein_probe.wxt.alert' later?
+# Add 'gcn.notices.einstein_probe.wxt.alert' later? 
+# example of received json can be found here https://github.com/nasa-gcn/gcn-schema/blob/v4.0.0/gcn/notices/einstein_probe/wxt/alert.schema.example.json
+consumer.subscribe(['gcn.notices.swift.bat.guano'])  
+
 
 def post_to_slack(channel, message):
     """Post a message to a Slack channel."""

--- a/gcn-alert/gcn_kafka_receiver.py
+++ b/gcn-alert/gcn_kafka_receiver.py
@@ -60,7 +60,13 @@ while True:
             event_time = datetime.strptime(alert["trigger_time"], '%Y-%m-%dT%H:%M:%S.%fZ')
             current_time = datetime.utcnow()
 
-            if rate_duration < 2 and (current_time - event_time) < timedelta(minutes=10) and alert["alert_type"] == "initial":
+            if (
+                rate_duration < 2 
+                and (current_time - event_time) < timedelta(minutes=10)
+                and "ra" in alert
+                and "dec" in alert
+                and "radius" in alert
+            ):
                 logger.info(f'Event at {alert["alert_datetime"]}: RA, Dec = ({alert["ra"]}, {alert["dec"]}, radius={alert["radius"]}).')
                 logger.info(f'Rate_duration: {rate_duration}. Rate_snr: {alert["rate_snr"]}.')
 

--- a/gcn-alert/gcn_kafka_receiver.py
+++ b/gcn-alert/gcn_kafka_receiver.py
@@ -71,10 +71,19 @@ while True:
                 logger.info(f'Rate_duration: {rate_duration}. Rate_snr: {alert["rate_snr"]}.')
 
                 # duration is set to one hour
-                args = {'duration': 3600, 'position': f'{alert["ra"]},{alert["dec"]},{alert["radius"]}'}
+                args = args = {
+                    'duration': 3600, 
+                    'position': f'{alert["ra"]},{alert["dec"]},{alert["radius"]}',
+                    'instrument': alert["instrument"],
+                    'mission': alert["mission"]
+                }
                 gc.set('gcn', args)
 
-                message = f"Swift/BAT-GUANO Alert: RA, Dec = ({alert['ra']}, {alert['dec']}, radius={alert['radius']}).\nRate_duration: {rate_duration}. Rate_snr: {alert['rate_snr']}."
+                message = (
+                    f"Swift/BAT-GUANO Alert: RA, Dec = ({alert['ra']}, {alert['dec']}, radius={alert['radius']}).\n"
+                    f"Rate_duration: {rate_duration}. Rate_snr: {alert['rate_snr']}.\n"
+                    f"Instrument: {alert['instrument']}. Mission: {alert['mission']}."
+                )
                 if send_to_slack:
                     post_to_slack(slack_channel, message)
 

--- a/gcn-alert/gcn_kafka_receiver.py
+++ b/gcn-alert/gcn_kafka_receiver.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+from ovro_alert import alert_client
+from gcn_kafka import Consumer
+from datetime import datetime, timedelta
+from os import environ
+import sys
+import logging
+import json
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+gc = alert_client.AlertClient('gcn')
+
+logger = logging.getLogger(__name__)
+logHandler = logging.StreamHandler(sys.stdout)
+logFormat = logging.Formatter('%(asctime)s [%(levelname)-8s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+logHandler.setFormatter(logFormat)
+logger.addHandler(logHandler)
+logger.setLevel(logging.DEBUG)
+
+client_id = environ.get("GCN_KAFKA_CLIENT_ID")
+client_secret = environ.get("GCN_KAFKA_CLIENT_SECRET")
+
+if not client_id or not client_secret:
+    logger.error("GCN_KAFKA_CLIENT_ID and GCN_KAFKA_CLIENT_SECRET must be set in the environment.")
+    sys.exit(1)
+
+slack_token = environ.get("SLACK_TOKEN_CR")
+slack_channel = "#alert-driven-astro"  # use your actual Slack channel
+send_to_slack = bool(slack_token)
+
+if slack_token:
+    slack_client = WebClient(token=slack_token)
+    logger.debug("Created Slack client")
+
+consumer = Consumer(client_id=client_id, client_secret=client_secret)
+
+consumer.subscribe(['gcn.notices.swift.bat.guano'])  # Add 'gcn.notices.einstein_probe.wxt.alert' later?
+
+def post_to_slack(channel, message):
+    """Post a message to a Slack channel."""
+    try:
+        response = slack_client.chat_postMessage(channel=channel, text=message)
+    except SlackApiError as e:
+        logger.error(f"Error sending to Slack: {e.response['error']}")
+
+while True:
+    for message in consumer.consume(timeout=1):
+        if message.error():
+            logger.error(message.error())
+            continue
+
+        try:
+            alert = json.loads(message.value().decode('utf-8'))
+            
+            rate_duration = alert["rate_duration"]
+            event_time = datetime.strptime(alert["trigger_time"], '%Y-%m-%dT%H:%M:%S.%fZ')
+            current_time = datetime.utcnow()
+
+            if rate_duration < 2 and (current_time - event_time) < timedelta(minutes=10) and alert["alert_type"] == "initial":
+                logger.info(f'Event at {alert["alert_datetime"]}: RA, Dec = ({alert["ra"]}, {alert["dec"]}, radius={alert["radius"]}).')
+                logger.info(f'Rate_duration: {rate_duration}. Rate_snr: {alert["rate_snr"]}.')
+
+                # duration is set to one hour
+                args = {'duration': 3600, 'position': f'{alert["ra"]},{alert["dec"]},{alert["radius"]}'}
+                gc.set('gcn', args)
+
+                message = f"Swift/BAT-GUANO Alert: RA, Dec = ({alert['ra']}, {alert['dec']}, radius={alert['radius']}).\nRate_duration: {rate_duration}. Rate_snr: {alert['rate_snr']}."
+                if send_to_slack:
+                    post_to_slack(slack_channel, message)
+
+        except Exception as e:
+            logger.error(f'Error processing message: {e}')

--- a/gcn-alert/gcn_kafka_receiver.py
+++ b/gcn-alert/gcn_kafka_receiver.py
@@ -80,9 +80,9 @@ while True:
                 gc.set('gcn', args)
 
                 message = (
-                    f"Swift/BAT-GUANO Alert: RA, Dec = ({alert['ra']}, {alert['dec']}, radius={alert['radius']}).\n"
-                    f"Rate_duration: {rate_duration}. Rate_snr: {alert['rate_snr']}.\n"
-                    f"Instrument: {alert['instrument']}. Mission: {alert['mission']}."
+                    f"GCN alert: Instrument: {alert['instrument']}. Mission: {alert['mission']}.\n"
+                    f"RA, Dec = ({alert['ra']}, {alert['dec']}, radius={alert['radius']}).\n"
+                    f"Rate_duration: {rate_duration}. Rate_snr: {alert['rate_snr']}."
                 )
                 if send_to_slack:
                     post_to_slack(slack_channel, message)


### PR DESCRIPTION
@caseyjlaw Can you take a look at the implementation of the GCN Classic over Kafka consumer for Swift alerts?

**Thresholds:**
- `rate_duration` < 2 seconds to only detect short GRBs.
- Alerts must be received within 10 minutes of the event. Should I change this?
- Alerts must contain `ra`, `dec`, and `radius`.

---
- The duration for LWA recording is arbitrarily set to 1 hour. Do you think it's reasonable?
- Slack messaging has been added as for LIGO events.